### PR TITLE
bugfix

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -18306,7 +18306,7 @@ return lib.skill.rerende.ai.result.target(player,target);
 },
 effect:{
 target:function(card,player,target){
-return lib.skill.rerende.ai.effect.target(card,player,target);
+return lib.skill.rerende.ai.effect.target_use(card,player,target);
 },
 },
 },


### PR DESCRIPTION
修复我此前为解决人机对刘辩【诗怨】“成为目标”实际考虑为牌生效时刻收益的问题将ai.effect.target改ai.effect.target_use引起的调用错误
二者区别举例：
ai.effect.target_use：假设返回值是[1,3]，那么队友可能对你用原本是负收益的牌。如果它有能让此牌失效的技能/牌（无懈锦囊、取消目标等等），它会对你用，因为这个**影响的只是选择目标的ai**，卡牌收益还是负的
ai.effect.target：与ai.effect.target_use的区别是，如果它有能让此牌失效的技能/牌（无懈锦囊、取消目标等等），它不会对你用，因为卡牌收益**还会被**ai.effect.target**影响成正的**
同理还有ai.effect.player_use